### PR TITLE
Corrected requirement oauth-lib to oauthlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='YHandler',
       license='MIT',
       packages=['YHandler'],
       install_requires=[
-            'oauth-lib',
+            'oauthlib',
             'requests',
             'lxml'
       ],


### PR DESCRIPTION
Typo in oauth requirement
